### PR TITLE
Remove review buttons from setup page

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -81,8 +81,6 @@
         </label>
         <label class="row" style="gap:6px"><span class="muted">サーバ保存URL</span><input id="endpoint" type="text" value="http://192.168.50.122/api/results" placeholder="/api/results" style="min-width:260px"/></label>
         <button class="primary" id="btn-start">▶ 学習スタート</button>
-        <button id="btn-review" title="間違えた問題だけで出題">🔁 復習（まちがい）</button>
-        <button id="btn-review-recent" title="最近のまちがいを優先">🕘 復習（最近）</button>
         <button id="btn-weak" title="過去7日の正答率が低い問題">🎯 弱点対策（過去7日）</button>
       </div>
       <div class="muted" style="margin-top:8px">
@@ -587,29 +585,6 @@
         rememberUserAndEndpoint();
         await startSet();
       }catch(e){ alert('開始できません: '+(e.message||e)); }
-    };
-    document.getElementById('btn-review').onclick=async ()=>{
-      try{
-        state.user=(document.getElementById('learner').value||'guest').trim()||'guest';
-        document.getElementById('user-pill').textContent=`👤 ${state.user}`;
-        state.totalPerSet=Math.max(3,Math.min(20,parseInt(document.getElementById('count').value||5,10)));
-        state.endpoint=document.getElementById('endpoint').value.trim() || DEFAULT_ENDPOINT; document.getElementById('endpoint').value = state.endpoint;
-        state.setIndex=0; state.mode='review'; state.reviewStrategy='all'; state.qType=document.getElementById('qtype').value||'reorder';
-        rememberUserAndEndpoint();
-        await startSet();
-      }catch(e){ alert('復習を開始できません: '+(e.message||e)); }
-    };
-    // 最近のまちがい優先
-    document.getElementById('btn-review-recent').onclick=async ()=>{
-      try{
-        state.user=(document.getElementById('learner').value||'guest').trim()||'guest';
-        document.getElementById('user-pill').textContent=`👤 ${state.user}`;
-        state.totalPerSet=Math.max(3,Math.min(20,parseInt(document.getElementById('count').value||5,10)));
-        state.endpoint=document.getElementById('endpoint').value.trim() || DEFAULT_ENDPOINT; document.getElementById('endpoint').value = state.endpoint;
-        state.setIndex=0; state.mode='review'; state.reviewStrategy='recent'; state.qType=document.getElementById('qtype').value||'reorder';
-        rememberUserAndEndpoint();
-        await startSet();
-      }catch(e){ alert('最近の復習を開始できません: '+(e.message||e)); }
     };
 
     document.getElementById('btn-review-thisset').onclick = async ()=>{


### PR DESCRIPTION
## Summary
- remove mistake and recent review buttons from setup page
- delete unused review event handlers

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a653099a5083339802fbe5db0bca2d